### PR TITLE
Remove cmake_minimum_required call from FindLibzip

### DIFF
--- a/cmake/FindLibzip.cmake
+++ b/cmake/FindLibzip.cmake
@@ -6,8 +6,6 @@
 #   LIBZIP_LIBRARIES      - List of libraries to link when using libzip.
 #   LIBZIP_FOUND          - True if libzip found.
 
-cmake_minimum_required (VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
-
 find_path(LIBZIP_INCLUDE_DIR NAMES zip.h)
 mark_as_advanced(LIBZIP_INCLUDE_DIR)
 


### PR DESCRIPTION
Find<package>.cmake script do not contain tipically the `cmake_minum_required_version` call, see for example: 
* https://github.com/Kitware/CMake/blob/master/Modules/FindPNG.cmake
* https://github.com/KDE/extra-cmake-modules/blob/master/find-modules/FindOpenEXR.cmake 

Furthermore, `CMAKE_MINIMUM_REQUIRED_VERSION` was removed in https://github.com/SFI-Mechatronics/FMI4cpp/commit/784db15863e7a07b3681dca3289caf638aa92a11