### PR TITLE
use boost::optional over std::shared_ptr to represent FMI optional values

### DIFF
--- a/include/fmicpp/fmi2/xml/DefaultExperiment.hpp
+++ b/include/fmicpp/fmi2/xml/DefaultExperiment.hpp
@@ -25,8 +25,8 @@
 #ifndef FMICPP_DEFAULTEXPERIMENT_HPP
 #define FMICPP_DEFAULTEXPERIMENT_HPP
 
-#include <memory>
 #include <ostream>
+#include <boost/optional.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 using boost::property_tree::ptree;
@@ -36,19 +36,19 @@ namespace fmicpp::fmi2::xml {
     struct DefaultExperiment {
 
     private:
-        std::shared_ptr<double> startTime_;
-        std::shared_ptr<double> stopTime_;
-        std::shared_ptr<double> stepSize_;
-        std::shared_ptr<double> tolerance_;
+        boost::optional<double> startTime_;
+        boost::optional<double> stopTime_;
+        boost::optional<double> stepSize_;
+        boost::optional<double> tolerance_;
 
     public:
-        std::shared_ptr<double> startTime() const;
+        boost::optional<double> startTime() const;
 
-        std::shared_ptr<double> stopTime() const;
+        boost::optional<double> stopTime() const;
 
-        std::shared_ptr<double> stepSize() const;
+        boost::optional<double> stepSize() const;
 
-        std::shared_ptr<double> tolerance() const;
+        boost::optional<double> tolerance() const;
 
         void load(const ptree &node);
 

--- a/include/fmicpp/fmi2/xml/ModelDescription.hpp
+++ b/include/fmicpp/fmi2/xml/ModelDescription.hpp
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <string>
+#include <boost/optional.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
@@ -64,7 +65,7 @@ namespace fmicpp::fmi2::xml {
 
         ModelVariables modelVariables_;
         ModelStructure modelStructure_;
-        shared_ptr<DefaultExperiment> defaultExperiment_;
+        boost::optional<DefaultExperiment> defaultExperiment_;
 
         shared_ptr<CoSimulationAttributes> coSimulation_ = nullptr;
         shared_ptr<ModelExchangeAttributes> modelExchange_ = nullptr;
@@ -99,7 +100,7 @@ namespace fmicpp::fmi2::xml {
 
         const ModelStructure &modelStructure() const;
 
-        const shared_ptr<DefaultExperiment> defaultExperiment() const;
+        const boost::optional<DefaultExperiment> defaultExperiment() const;
 
         bool supportsModelExchange() const;
 

--- a/include/fmicpp/fmi2/xml/ModelStructure.hpp
+++ b/include/fmicpp/fmi2/xml/ModelStructure.hpp
@@ -27,7 +27,7 @@
 
 #include <string>
 #include <vector>
-#include <memory>
+#include <boost/optional.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include "../fmi2TypesPlatform.h"
@@ -40,15 +40,15 @@ namespace fmicpp::fmi2::xml {
 
     private:
         unsigned int index_;
-        std::string dependencyKind_;
-        std::shared_ptr<std::vector<unsigned int >> dependencies_;
+        boost::optional<std::string> dependencyKind_;
+        boost::optional<std::vector<unsigned int >> dependencies_;
 
     public:
         unsigned int index() const;
 
-        std::string dependencyKind() const;
+        boost::optional<std::string> dependencyKind() const;
 
-        const std::vector<unsigned int> &dependencies() const;
+        const boost::optional<std::vector<unsigned int>> &dependencies() const;
 
         void load(const ptree &node);
 

--- a/include/fmicpp/fmi2/xml/ScalarVariable.hpp
+++ b/include/fmicpp/fmi2/xml/ScalarVariable.hpp
@@ -26,6 +26,7 @@
 #define FMICPP_SCALARVARIABLE_HPP
 
 #include <memory>
+#include <boost/optional.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include "enums.hpp"
@@ -33,7 +34,6 @@
 #include "ScalarVariableAttributes.hpp"
 
 using std::string;
-using std::shared_ptr;
 using boost::property_tree::ptree;
 
 namespace fmicpp::fmi2::xml {
@@ -61,11 +61,11 @@ namespace fmicpp::fmi2::xml {
         fmi2Variability variability_;
         fmi2Initial initial_;
 
-        shared_ptr<IntegerAttribute> integerAttribute_;
-        shared_ptr<RealAttribute> realAttribute_;
-        shared_ptr<StringAttribute> stringAttribute_;
-        shared_ptr<BooleanAttribute> booleanAttribute_;
-        shared_ptr<EnumerationAttribute> enumerationAttribute_;
+        std::shared_ptr<IntegerAttribute> integerAttribute_;
+        std::shared_ptr<RealAttribute> realAttribute_;
+        std::shared_ptr<StringAttribute> stringAttribute_;
+        std::shared_ptr<BooleanAttribute> booleanAttribute_;
+        std::shared_ptr<EnumerationAttribute> enumerationAttribute_;
 
     public:
 
@@ -105,15 +105,15 @@ namespace fmicpp::fmi2::xml {
     public:
         IntegerVariable(const ScalarVariable &var, IntegerAttribute &attribute);
 
-        shared_ptr<int> getMin() const;
+        boost::optional<int> getMin() const;
 
-        shared_ptr<int> getMax() const;
+        boost::optional<int> getMax() const;
 
-        shared_ptr<int> getStart() const;
+        boost::optional<int> getStart() const;
 
         void setStart(const int start);
 
-        shared_ptr<string> getQuantity() const;
+        boost::optional<string> getQuantity() const;
 
     };
 
@@ -125,15 +125,15 @@ namespace fmicpp::fmi2::xml {
     public:
         RealVariable(const ScalarVariable &var, RealAttribute &attribute);
 
-        shared_ptr<double> getMin() const;
+        boost::optional<double> getMin() const;
 
-        shared_ptr<double> getMax() const;
+        boost::optional<double> getMax() const;
 
-        shared_ptr<double> getStart() const;
+        boost::optional<double> getStart() const;
 
         void setStart(const double start);
 
-        shared_ptr<double> getNominal() const;
+        boost::optional<double> getNominal() const;
 
         bool getReinit() const;
 
@@ -141,13 +141,13 @@ namespace fmicpp::fmi2::xml {
 
         bool getRelativeQuantity() const;
 
-        shared_ptr<string> getQuantity() const;
+        boost::optional<string> getQuantity() const;
 
-        shared_ptr<string> getUnit() const;
+        boost::optional<string> getUnit() const;
 
-        shared_ptr<string> getDisplayUnit() const;
+        boost::optional<string> getDisplayUnit() const;
 
-        shared_ptr<unsigned int> getDerivative() const;
+        boost::optional<unsigned int> getDerivative() const;
 
     };
 
@@ -159,7 +159,7 @@ namespace fmicpp::fmi2::xml {
     public:
         StringVariable(const ScalarVariable &var, StringAttribute &attribute);
 
-        shared_ptr<string> getStart() const;
+        boost::optional<string> getStart() const;
 
         void setStart(const string &start);
 
@@ -173,7 +173,7 @@ namespace fmicpp::fmi2::xml {
     public:
         BooleanVariable(const ScalarVariable &var, BooleanAttribute &attribute);
 
-        shared_ptr<bool> getStart() const;
+        boost::optional<bool> getStart() const;
 
         void setStart(const bool start);
 
@@ -187,15 +187,15 @@ namespace fmicpp::fmi2::xml {
     public:
         EnumerationVariable(const ScalarVariable &var, EnumerationAttribute &attribute);
 
-        shared_ptr<int> getMin() const;
+        boost::optional<int> getMin() const;
 
-        shared_ptr<int> getMax() const;
+        boost::optional<int> getMax() const;
 
-        shared_ptr<int> getStart() const;
+        boost::optional<int> getStart() const;
 
         void setStart(const int start);
 
-        shared_ptr<string> getQuantity() const;
+        boost::optional<string> getQuantity() const;
 
     };
 

--- a/include/fmicpp/fmi2/xml/ScalarVariableAttributes.hpp
+++ b/include/fmicpp/fmi2/xml/ScalarVariableAttributes.hpp
@@ -25,37 +25,36 @@
 #ifndef FMICPP_SCALARVARIBALEATTRIBUTES_HPP
 #define FMICPP_SCALARVARIBALEATTRIBUTES_HPP
 
-#include <memory>
+#include <boost/optional.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 using std::string;
-using std::shared_ptr;
 using boost::property_tree::ptree;
 
 namespace fmicpp::fmi2::xml {
 
     struct IntegerAttribute {
 
-        shared_ptr<int> min;
-        shared_ptr<int> max;
-        shared_ptr<int> start;
+        boost::optional<int> min;
+        boost::optional<int> max;
+        boost::optional<int> start;
 
-        shared_ptr<string> quantity;
+        boost::optional<string> quantity;
 
         void load(const ptree &node);
     };
 
     struct RealAttribute {
-        shared_ptr<double> min;
-        shared_ptr<double> max;
-        shared_ptr<double> start;
-        shared_ptr<double> nominal;
+        boost::optional<double> min;
+        boost::optional<double> max;
+        boost::optional<double> start;
+        boost::optional<double> nominal;
 
-        shared_ptr<string> quantity;
-        shared_ptr<string> unit;
-        shared_ptr<string> displayUnit;
+        boost::optional<string> quantity;
+        boost::optional<string> unit;
+        boost::optional<string> displayUnit;
 
-        shared_ptr<unsigned int> derivative;
+        boost::optional<unsigned int> derivative;
 
         bool reinit;
         bool unbounded;
@@ -65,23 +64,23 @@ namespace fmicpp::fmi2::xml {
     };
 
     struct StringAttribute {
-        shared_ptr<string> start;
+        boost::optional<string> start;
 
         void load(const ptree &node);
     };
 
     struct BooleanAttribute {
-        shared_ptr<bool> start;
+        boost::optional<bool> start;
 
         void load(const ptree &node);
     };
 
     struct EnumerationAttribute {
-        shared_ptr<int> min;
-        shared_ptr<int> max;
-        shared_ptr<int> start;
+        boost::optional<int> min;
+        boost::optional<int> max;
+        boost::optional<int> start;
 
-        shared_ptr<string> quantity;
+        boost::optional<string> quantity;
 
         void load(const ptree &node);
     };

--- a/src/fmicpp/fmi2/xml/DefaultExperiment.cpp
+++ b/src/fmicpp/fmi2/xml/DefaultExperiment.cpp
@@ -27,36 +27,24 @@
 using namespace fmicpp::fmi2::xml;
 
 void DefaultExperiment::load(const ptree &node) {
-    auto startTime_optional = node.get_optional<double>("<xmlattr>.startTime");
-    if (startTime_optional) {
-        startTime_ = std::make_shared<double>(*startTime_optional);
-    }
-    auto stopTime_optional = node.get_optional<double>("<xmlattr>.stopTime");
-    if (stopTime_optional) {
-        stopTime_ = std::make_shared<double>(*stopTime_optional);
-    }
-    auto stepSize_optional = node.get_optional<double>("<xmlattr>.stepSize");
-    if (stepSize_optional) {
-        stepSize_ = std::make_shared<double>(*stepSize_optional);
-    }
-    auto tolerance_optional = node.get_optional<double>("<xmlattr>.tolerance");
-    if (tolerance_optional) {
-        tolerance_ = std::make_shared<double>(*tolerance_optional);
-    }
+    startTime_ = node.get_optional<double>("<xmlattr>.startTime");
+    stopTime_ = node.get_optional<double>("<xmlattr>.stopTime");
+    stepSize_ = node.get_optional<double>("<xmlattr>.stepSize");
+    tolerance_ = node.get_optional<double>("<xmlattr>.tolerance");
 }
 
-std::shared_ptr<double> DefaultExperiment::startTime() const {
+boost::optional<double> DefaultExperiment::startTime() const {
     return startTime_;
 }
 
-std::shared_ptr<double> DefaultExperiment::stopTime() const {
+boost::optional<double> DefaultExperiment::stopTime() const {
     return stopTime_;
 }
 
-std::shared_ptr<double> DefaultExperiment::stepSize() const {
+boost::optional<double> DefaultExperiment::stepSize() const {
     return stepSize_;
 }
 
-std::shared_ptr<double> DefaultExperiment::tolerance() const {
+boost::optional<double> DefaultExperiment::tolerance() const {
     return tolerance_;
 }

--- a/src/fmicpp/fmi2/xml/ModelDescription.cpp
+++ b/src/fmicpp/fmi2/xml/ModelDescription.cpp
@@ -55,7 +55,7 @@ void ModelDescription::load(const string &fileName) {
             modelExchange_ = make_shared<ModelExchangeAttributes>();
             modelExchange_->load(v.second);
         } else if (v.first == "DefaultExperiment") {
-            defaultExperiment_ = make_shared<DefaultExperiment>();
+            defaultExperiment_ = DefaultExperiment();
             defaultExperiment_->load(v.second);
         } else if (v.first == "ModelVariables") {
             modelVariables_.load(v.second);
@@ -123,7 +123,7 @@ const ModelStructure &ModelDescription::modelStructure() const {
     return modelStructure_;
 }
 
-const shared_ptr<DefaultExperiment> ModelDescription::defaultExperiment() const {
+const boost::optional<DefaultExperiment> ModelDescription::defaultExperiment() const {
     return defaultExperiment_;
 }
 

--- a/src/fmicpp/fmi2/xml/ModelStructure.cpp
+++ b/src/fmicpp/fmi2/xml/ModelStructure.cpp
@@ -49,11 +49,11 @@ unsigned int Unknown::index() const {
     return index_;
 }
 
-std::string Unknown::dependencyKind() const {
+boost::optional<std::string> Unknown::dependencyKind() const {
     return dependencyKind_;
 }
 
-const std::vector<unsigned int> &Unknown::dependencies() const {
+const boost::optional<std::vector<unsigned int>> &Unknown::dependencies() const {
     return *dependencies_;
 }
 

--- a/src/fmicpp/fmi2/xml/ScalarVariable.cpp
+++ b/src/fmicpp/fmi2/xml/ScalarVariable.cpp
@@ -126,46 +126,46 @@ fmi2Initial ScalarVariable::getInitial() const {
 IntegerVariable::IntegerVariable(const ScalarVariable &var, IntegerAttribute &attribute)
         : ScalarVariable(var), attribute_(attribute) {}
 
-shared_ptr<int> IntegerVariable::getMin() const {
+boost::optional<int> IntegerVariable::getMin() const {
     return attribute_.min;
 }
 
-shared_ptr<int> IntegerVariable::getMax() const {
+boost::optional<int> IntegerVariable::getMax() const {
     return attribute_.max;
 }
 
-shared_ptr<int> IntegerVariable::getStart() const {
+boost::optional<int> IntegerVariable::getStart() const {
     return attribute_.start;
 }
 
 void IntegerVariable::setStart(const int start) {
-    attribute_.start = make_shared<int>(start);
+    attribute_.start = start;
 }
 
-shared_ptr<string> IntegerVariable::getQuantity() const {
+boost::optional<string> IntegerVariable::getQuantity() const {
     return attribute_.quantity;
 }
 
 RealVariable::RealVariable(const ScalarVariable &var, RealAttribute &attribute)
         : ScalarVariable(var), attribute_(attribute) {}
 
-shared_ptr<double> RealVariable::getMin() const {
+boost::optional<double> RealVariable::getMin() const {
     return attribute_.min;
 }
 
-shared_ptr<double> RealVariable::getMax() const {
+boost::optional<double> RealVariable::getMax() const {
     return attribute_.max;
 }
 
-shared_ptr<double> RealVariable::getStart() const {
+boost::optional<double> RealVariable::getStart() const {
     return attribute_.start;
 }
 
 void RealVariable::setStart(const double start) {
-    attribute_.start = make_shared<double>(start);
+    attribute_.start = start;
 }
 
-shared_ptr<double> RealVariable::getNominal() const {
+boost::optional<double> RealVariable::getNominal() const {
     return attribute_.nominal;
 }
 
@@ -181,37 +181,37 @@ bool RealVariable::getRelativeQuantity() const {
     return attribute_.relativeQuantity;
 }
 
-shared_ptr<string> RealVariable::getQuantity() const {
+boost::optional<string> RealVariable::getQuantity() const {
     return attribute_.quantity;
 }
 
-shared_ptr<string> RealVariable::getUnit() const {
+boost::optional<string> RealVariable::getUnit() const {
     return attribute_.unit;
 }
 
-shared_ptr<string> RealVariable::getDisplayUnit() const {
+boost::optional<string> RealVariable::getDisplayUnit() const {
     return attribute_.displayUnit;
 }
 
-shared_ptr<unsigned int> RealVariable::getDerivative() const {
+boost::optional<unsigned int> RealVariable::getDerivative() const {
     return attribute_.derivative;
 }
 
 StringVariable::StringVariable(const ScalarVariable &var, StringAttribute &attribute)
         : ScalarVariable(var), attribute_(attribute) {}
 
-shared_ptr<string> StringVariable::getStart() const {
+boost::optional<string> StringVariable::getStart() const {
     return attribute_.start;
 }
 
 void StringVariable::setStart(const string &start) {
-    attribute_.start = make_shared<string>(start);
+    attribute_.start = start;
 }
 
 BooleanVariable::BooleanVariable(const ScalarVariable &var, BooleanAttribute &attribute)
         : ScalarVariable(var), attribute_(attribute) {}
 
-shared_ptr<bool> BooleanVariable::getStart() const {
+boost::optional<bool> BooleanVariable::getStart() const {
     return attribute_.start;
 }
 
@@ -222,22 +222,22 @@ void BooleanVariable::setStart(const bool start) {
 EnumerationVariable::EnumerationVariable(const ScalarVariable &var, EnumerationAttribute &attribute)
         : ScalarVariable(var), attribute_(attribute) {}
 
-shared_ptr<int> EnumerationVariable::getMin() const {
+boost::optional<int> EnumerationVariable::getMin() const {
     return attribute_.min;
 }
 
-shared_ptr<int> EnumerationVariable::getMax() const {
+boost::optional<int> EnumerationVariable::getMax() const {
     return attribute_.max;
 }
 
-shared_ptr<int> EnumerationVariable::getStart() const {
+boost::optional<int> EnumerationVariable::getStart() const {
     return attribute_.start;
 }
 
 void EnumerationVariable::setStart(const int start) {
-    attribute_.start = make_shared<int>(start);
+    attribute_.start = start;
 }
 
-shared_ptr<string> EnumerationVariable::getQuantity() const {
+boost::optional<string> EnumerationVariable::getQuantity() const {
     return attribute_.quantity;
 }

--- a/src/fmicpp/fmi2/xml/ScalarVariableAttributes.cpp
+++ b/src/fmicpp/fmi2/xml/ScalarVariableAttributes.cpp
@@ -28,60 +28,24 @@ using namespace std;
 using namespace fmicpp::fmi2::xml;
 
 void IntegerAttribute::load(const ptree &node) {
-    auto min_optional = node.get_optional<int>("<xmlattr>.min");
-    if (min_optional) {
-        min = make_shared<int>(*min_optional);
-    }
-    auto max_optional = node.get_optional<int>("<xmlattr>.max");
-    if (max_optional) {
-        max = make_shared<int>(*max_optional);
-    }
-    auto start_optional = node.get_optional<int>("<xmlattr>.start");
-    if (start_optional) {
-        start = make_shared<int>(*start_optional);
-    }
-    auto quantity_optional = node.get_optional<string>("<xmlattr>.quantity");
-    if (quantity_optional) {
-        quantity = make_shared<string>(*quantity_optional);
-    }
+    min = node.get_optional<int>("<xmlattr>.min");
+    max = node.get_optional<int>("<xmlattr>.max");
+    start = node.get_optional<int>("<xmlattr>.start");
 
+    quantity = node.get_optional<string>("<xmlattr>.quantity");
 }
 
 void RealAttribute::load(const ptree &node) {
-    auto min_optional = node.get_optional<double>("<xmlattr>.min");
-    if (min_optional) {
-        min = make_shared<double>(*min_optional);
-    }
-    auto max_optional = node.get_optional<double>("<xmlattr>.max");
-    if (max_optional) {
-        max = make_shared<double>(*max_optional);
-    }
-    auto start_optional = node.get_optional<double>("<xmlattr>.start");
-    if (start_optional) {
-        start = make_shared<double>(*start_optional);
-    }
-    auto nominal_optional = node.get_optional<double>("<xmlattr>.nominal");
-    if (nominal_optional) {
-        nominal = make_shared<double>(*nominal_optional);
-    }
+    min = node.get_optional<double>("<xmlattr>.min");
+    max = node.get_optional<double>("<xmlattr>.max");
+    start = node.get_optional<double>("<xmlattr>.start");
+    nominal = node.get_optional<double>("<xmlattr>.nominal");
 
-    auto quantity_optional = node.get_optional<string>("<xmlattr>.quantity");
-    if (quantity_optional) {
-        quantity = make_shared<string>(*quantity_optional);
-    }
-    auto unit_optional = node.get_optional<string>("<xmlattr>.unit");
-    if (unit_optional) {
-        unit = make_shared<string>(*unit_optional);
-    }
-    auto displayUnit_optional = node.get_optional<string>("<xmlattr>.displayUnit");
-    if (displayUnit_optional) {
-        displayUnit = make_shared<string>(*displayUnit_optional);
-    }
+    quantity = node.get_optional<string>("<xmlattr>.quantity");
+    unit = node.get_optional<string>("<xmlattr>.unit");
+    displayUnit = node.get_optional<string>("<xmlattr>.displayUnit");
 
-    auto derivative_optional = node.get_optional<unsigned int>("<xmlattr>.derivative");
-    if (derivative_optional) {
-        derivative = make_shared<unsigned int>(*derivative_optional);
-    }
+    derivative = node.get_optional<unsigned int>("<xmlattr>.derivative");
 
     reinit = node.get<bool>("<xmlattr>.reinit", false);
     unbounded = node.get<bool>("<xmlattr>.unbounded", false);
@@ -90,34 +54,17 @@ void RealAttribute::load(const ptree &node) {
 }
 
 void StringAttribute::load(const ptree &node) {
-    auto start_optional = node.get_optional<string>("<xmlattr>.start");
-    if (start_optional) {
-        start = make_shared<string>(*start_optional);
-    }
+    start = node.get_optional<string>("<xmlattr>.start");
 }
 
 void BooleanAttribute::load(const ptree &node) {
-    auto start_optional = node.get_optional<bool>("<xmlattr>.start");
-    if (start_optional) {
-        start = make_shared<bool>(*start_optional);
-    }
+    start = node.get_optional<bool>("<xmlattr>.start");
 }
 
 void EnumerationAttribute::load(const ptree &node) {
-    auto min_optional = node.get_optional<int>("<xmlattr>.min");
-    if (min_optional) {
-        min = make_shared<int>(*min_optional);
-    }
-    auto max_optional = node.get_optional<int>("<xmlattr>.max");
-    if (max_optional) {
-        max = make_shared<int>(*max_optional);
-    }
-    auto start_optional = node.get_optional<int>("<xmlattr>.start");
-    if (start_optional) {
-        start = make_shared<int>(*start_optional);
-    }
-    auto quantity_optional = node.get_optional<string>("<xmlattr>.quantity");
-    if (quantity_optional) {
-        quantity = make_shared<string>(*quantity_optional);
-    }
+    min = node.get_optional<int>("<xmlattr>.min");
+    max = node.get_optional<int>("<xmlattr>.max");
+    start = node.get_optional<int>("<xmlattr>.start");
+
+    quantity = node.get_optional<string>("<xmlattr>.quantity");
 }

--- a/tests/test_modeldescription1.cpp
+++ b/tests/test_modeldescription1.cpp
@@ -60,11 +60,12 @@ BOOST_AUTO_TEST_CASE(test1) {
 
     auto heatCapacity1 = md.getVariableByName("HeatCapacity1.T0").asRealVariable();
     BOOST_CHECK_EQUAL(1, heatCapacity1.getValueReference());
-    BOOST_CHECK_EQUAL(nullptr, heatCapacity1.getMin());
-    BOOST_CHECK_EQUAL(nullptr, heatCapacity1.getMax());
+    BOOST_CHECK_EQUAL(false, heatCapacity1.getMin().has_value());
+    BOOST_CHECK_EQUAL(false, heatCapacity1.getMax().has_value());
+    BOOST_CHECK_EQUAL(true, heatCapacity1.getStart().has_value());
     BOOST_CHECK_EQUAL(298.0, *heatCapacity1.getStart());
     BOOST_CHECK_EQUAL("starting temperature", heatCapacity1.getDescription());
-    BOOST_CHECK_EQUAL(nullptr, heatCapacity1.getQuantity());
+    BOOST_CHECK_EQUAL(false, heatCapacity1.getQuantity().has_value());
 
     auto thermalConductor = md.getVariableByValueReference(12);
     BOOST_CHECK_EQUAL("TemperatureSource.T", thermalConductor.getName());
@@ -81,10 +82,10 @@ BOOST_AUTO_TEST_CASE(test1) {
     BOOST_CHECK_EQUAL(116, outputs[1].index());
 
     auto de = md.defaultExperiment();
-    BOOST_CHECK(de != nullptr);
+    BOOST_CHECK(de.has_value());
     BOOST_CHECK_EQUAL(0.0, *de->startTime());
     BOOST_CHECK_EQUAL(20.0, *de->stopTime());
     BOOST_CHECK_EQUAL(1E-4, *de->stepSize());
-    BOOST_CHECK_EQUAL(nullptr, de->tolerance());
+    BOOST_CHECK_EQUAL(false, de->tolerance().has_value());
 
 }


### PR DESCRIPTION
Closes #9