### PR TITLE
Fix compilation without vcpkg on Ubuntu 18.04 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 SET(VCPKG_ROOT $ENV{VCPKG_ROOT} CACHE STRING "VCPKG_ROOT")
-if (DEFINED VCPKG_ROOT AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+if (DEFINED VCPKG_ROOT AND NOT DEFINED CMAKE_TOOLCHAIN_FILE AND EXISTS "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
     set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
 endif ()
 
@@ -19,7 +19,7 @@ SET(BOOST_COMPONENTS system filesystem)
 if (BUILD_TESTS)
     SET(BOOST_COMPONENTS ${BOOST_COMPONENTS} unit_test_framework)
 endif ()
-find_package(Boost 1.67 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.65 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(Libzip REQUIRED)


### PR DESCRIPTION
I added a check to be able to compile on Ubuntu 18.04. 
I also reduced the required version of CMake and Boost, as everything seems to be working fine  even with those version, that are the one of the versions available in Ubuntu 18.04 .