### PR TITLE
Replace boost::filesystem with std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif ()
 
-SET(BOOST_COMPONENTS system filesystem)
+SET(BOOST_COMPONENTS system)
 if (BUILD_TESTS)
     SET(BOOST_COMPONENTS ${BOOST_COMPONENTS} unit_test_framework)
 endif ()

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ When the library is stable it will be added to the vcpkg package manager.
 Install [vcpkg](https://github.com/Microsoft/vcpkg) and run:
 
 ```
-./vcpkg install boost-property-tree boost-filesystem libzip
+./vcpkg install boost-property-tree libzip
 ``` 
 
 On linux you _might_ also need to install some additional libraries:

--- a/include/fmicpp/fmi2/import/Fmu.hpp
+++ b/include/fmicpp/fmi2/import/Fmu.hpp
@@ -27,20 +27,14 @@
 
 #include <memory>
 #include <vector>
-
-#ifdef WIN32
 #include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
-
 #include "../xml/ModelDescription.hpp"
 
 using std::string;
 using std::unique_ptr;
 using fmicpp::fmi2::xml::ModelDescription;
+
+namespace fs = std::experimental::filesystem;
 
 namespace fmicpp::fmi2::import {
 

--- a/include/fmicpp/fmi2/import/Fmu.hpp
+++ b/include/fmicpp/fmi2/import/Fmu.hpp
@@ -27,11 +27,16 @@
 
 #include <memory>
 #include <vector>
-#include <boost/filesystem.hpp>
+
+#ifdef WIN32
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
 
 #include "../xml/ModelDescription.hpp"
-
-namespace fs = boost::filesystem;
 
 using std::string;
 using std::unique_ptr;

--- a/include/fmicpp/tools/unzipper.hpp
+++ b/include/fmicpp/tools/unzipper.hpp
@@ -29,14 +29,9 @@
 #include <sstream>
 #include <zip.h>
 #include <string>
-
-#ifdef WIN32
 #include <experimental/filesystem>
+
 namespace fs = std::experimental::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
 
 namespace {
 

--- a/include/fmicpp/tools/unzipper.hpp
+++ b/include/fmicpp/tools/unzipper.hpp
@@ -29,9 +29,14 @@
 #include <sstream>
 #include <zip.h>
 #include <string>
-#include <boost/filesystem.hpp>
 
-namespace fs = boost::filesystem;
+#ifdef WIN32
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
 
 namespace {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,7 @@ SET(SOURCES
         fmicpp/fmi2/xml/ModelStructure.cpp)
 
 add_library(fmicpp ${HEADERS} ${SOURCES})
-target_link_libraries(fmicpp Boost::system Boost::filesystem ${LIBZIP_LIBRARIES})
+target_link_libraries(fmicpp Boost::system ${LIBZIP_LIBRARIES})
 target_include_directories(fmicpp PRIVATE ${LIBZIP_INCLUDE_DIRS})
 if (UNIX)
     target_link_libraries(fmicpp dl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(fmicpp ${HEADERS} ${SOURCES})
 target_link_libraries(fmicpp Boost::system ${LIBZIP_LIBRARIES})
 target_include_directories(fmicpp PRIVATE ${LIBZIP_INCLUDE_DIRS})
 if (UNIX)
-    target_link_libraries(fmicpp dl)
+    target_link_libraries(fmicpp dl stdc++fs)
 elseif (WIN32)
     target_link_libraries(fmicpp bcrypt) # required by boost::uuids
 endif ()

--- a/src/fmicpp/fmi2/import/FmiLibrary.cpp
+++ b/src/fmicpp/fmi2/import/FmiLibrary.cpp
@@ -24,9 +24,14 @@
 
 #ifndef NDEBUG
 
-#include <boost/filesystem.hpp>
+#ifdef WIN32
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
 
-namespace fs = boost::filesystem;
 #endif
 
 #include <sstream>

--- a/src/fmicpp/fmi2/import/FmiLibrary.cpp
+++ b/src/fmicpp/fmi2/import/FmiLibrary.cpp
@@ -24,13 +24,9 @@
 
 #ifndef NDEBUG
 
-#ifdef WIN32
+
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
 
 #endif
 


### PR DESCRIPTION
Use std::experimental::filesystem

Removes dependency on boost-filesystem