### PR TITLE
Add install and uninstall targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ if (DEFINED VCPKG_ROOT AND NOT DEFINED CMAKE_TOOLCHAIN_FILE AND EXISTS "${VCPKG_
     set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
 endif ()
 
-project(FMICPP)
+project(FMICPP
+        VERSION 0.0.1)
 
 set(CMAKE_CXX_STANDARD 17)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -36,3 +37,42 @@ endif ()
 if (BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif ()
+
+# Add install logic (see https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html)
+set(ConfigPackageLocation share/${PROJECT_NAME})
+
+export(EXPORT ${PROJECT_NAME}
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
+       NAMESPACE ${PROJECT_NAME}::)
+
+install(EXPORT ${PROJECT_NAME}
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${ConfigPackageLocation})
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+"include(CMakeFindDependencyMacro)
+find_dependency(Boost 1.65 COMPONENTS system filesystem REQUIRED)
+include(\"\${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Targets.cmake\")
+"
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+                                 VERSION ${PROJECT_VERSION}
+                                 COMPATIBILITY AnyNewerVersion)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION ${ConfigPackageLocation})
+
+# Add uninstall logic (see https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake)
+if (NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
+
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,22 @@
+# Based on https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-include_directories(../include)
+include(GNUInstallDirs)
 
 SET(HEADERS
 
@@ -59,10 +58,30 @@ SET(SOURCES
         fmicpp/fmi2/xml/ModelStructure.cpp)
 
 add_library(fmicpp ${HEADERS} ${SOURCES})
+
+target_include_directories(fmicpp PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
+                                         "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
 target_link_libraries(fmicpp Boost::system Boost::filesystem ${LIBZIP_LIBRARIES})
 target_include_directories(fmicpp PRIVATE ${LIBZIP_INCLUDE_DIRS})
+
 if (UNIX)
     target_link_libraries(fmicpp dl)
 elseif (WIN32)
     target_link_libraries(fmicpp bcrypt) # required by boost::uuids
 endif ()
+
+# Make sure that also downstream libraries that use fmicpp compile as C++17
+target_compile_features(fmicpp PUBLIC cxx_std_17)
+
+# Install target
+install(TARGETS fmicpp
+        EXPORT ${PROJECT_NAME}
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+# Install headers
+install(DIRECTORY ../include/
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        FILES_MATCHING REGEX ".*.(hpp|h)")


### PR DESCRIPTION
Fix https://github.com/SFI-Mechatronics/FMI4cpp/issues/8 . 
I tried to follow the latest CMake guidelines, and I added links to the relevant documentation in the comments. @markaren let me know if you prefer that I expand those. 

With this patch, you can install a given directory by specifying the `CMAKE_INSTALL_PREFIX` CMake variable. Once you installed the library, you can find it in a downstream project by adding the  `CMAKE_INSTALL_PREFIX` directory to the `CMAKE_PREFIX_PATH` cmake or environmental variables. 
In the downstream project the library can be used as in:
~~~cmake
find_package(FMICPP REQUIRED)

target_link_libraries(<target> PUBLIC FMICPP:fmicpp)
~~~

Additional work is necessary to make sure that the CMake package is [relocatable](https://cmake.org/cmake/help/v3.12/manual/cmake-packages.7.html#creating-relocatable-packages), but I though it was better to first get this initial support in. Relocatable packages are convenient for  inclusion in vcpkg (see https://github.com/Microsoft/vcpkg/issues/1027 and https://github.com/Microsoft/vcpkg/issues/77).

Regarding the naming, the name of the package is connected to the name of the project in CMake. is `FMICPP` ok? Is the library supposed to be called `FMI4cpp`, `FMICPP` or `fmicpp`?